### PR TITLE
Added support for using a fifo on windows with a Named Pipe. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/launch.json

--- a/serial-pcap
+++ b/serial-pcap
@@ -283,7 +283,7 @@ def do_sniff_once(options):
         # Wait for something to do
         events = sel.select()
 
-        fds = [fd.fileobj.fileno() for (fd,evt) in events]
+        fds = [fd.fileobj.fileno() for (fd, evt) in events]
         if out.fileno() not in fds:
             # Error on output, e.g. fifo closed on the other end
             break

--- a/serial-pcap
+++ b/serial-pcap
@@ -86,9 +86,9 @@ if os.name == 'nt':
             for wfd in w:
                 wfo:PcapFormatter = self.get_key(wfd).fileobj
                 pipe = wfo.out.pipe
-                _, available_bytes, _ = win32pipe.PeekNamedPipe(pipe, 0)
-                
-                if available_bytes != 0:
+                try:
+                    _, available_bytes, _ = win32pipe.PeekNamedPipe(pipe, 0)
+                except:
                     retw.append(wfd)
             
             return retr, retw, []
@@ -260,17 +260,17 @@ def do_sniff_once(options):
 
     count = 0
     if os.name == 'nt':
-        poll = WindowsSelector()
+        sel = WindowsSelector()
     else:
-        poll = selectors.DefaultSelector()
+        sel = selectors.DefaultSelector()
         
     # Wait to read data from serial, or until the fifo is closed
-    poll.register(ser, selectors.EVENT_READ)
-    poll.register(out, selectors.EVENT_WRITE)
+    sel.register(ser, selectors.EVENT_READ)
+    sel.register(out, selectors.EVENT_WRITE)
 
     while True:
         # Wait for something to do
-        events = poll.select()
+        events = sel.select()
 
         fds = [fd.fileobj.fileno() for (fd,evt) in events]
         if out.fileno() in fds:

--- a/serial-pcap
+++ b/serial-pcap
@@ -54,6 +54,7 @@ if os.name == 'nt':
     ######
 
     class WindowsPipe:
+        # Wrapper for the windows pipe using the pywin32 calls
         def __init__(self, pipe):
             self.pipe:HANDLEType = pipe
         
@@ -70,11 +71,16 @@ if os.name == 'nt':
             win32file.CloseHandle(self.pipe)
     
     class WindowsSerial(serial.Serial):
+        # Give our serial a "fd" of it's "COM" port number
         def fileno(self):
             return int(self.name[3:])
     
     class WindowsSelector(selectors.SelectSelector):
         def _select(self, r, w, _, timeout = None):
+            # Since we are only reading from serial writing to a pipe (for fifos) we
+            # can harcode in what types are going to be in the read and write arrays
+            #
+            # Implementation logic taken from the select(2) manpage 
             retr = []
             retw = []
             
@@ -88,8 +94,11 @@ if os.name == 'nt':
                 pipe = wfo.out.pipe
                 try:
                     _, available_bytes, _ = win32pipe.PeekNamedPipe(pipe, 0)
+                    
+                    if available_bytes == 0:
+                        retw.append(wfd)
                 except:
-                    retw.append(wfd)
+                    continue
             
             return retr, retw, []
                 
@@ -99,6 +108,7 @@ if os.name == 'nt':
     ######
 
     def open_fifo_windows(options, name):
+        # Create named Pipe
         pipe = win32pipe.CreateNamedPipe(
             fr'\\.\pipe\{name}',
             win32pipe.PIPE_ACCESS_DUPLEX,
@@ -258,7 +268,6 @@ def do_sniff_once(options):
     if not options.quiet:
         print("Waiting for packets...")
 
-    count = 0
     if os.name == 'nt':
         sel = WindowsSelector()
     else:
@@ -268,12 +277,14 @@ def do_sniff_once(options):
     sel.register(ser, selectors.EVENT_READ)
     sel.register(out, selectors.EVENT_WRITE)
 
+    count = 0
+
     while True:
         # Wait for something to do
         events = sel.select()
 
         fds = [fd.fileobj.fileno() for (fd,evt) in events]
-        if out.fileno() in fds:
+        if out.fileno() not in fds:
             # Error on output, e.g. fifo closed on the other end
             break
         elif ser.fileno() in fds:

--- a/serial-pcap
+++ b/serial-pcap
@@ -125,7 +125,7 @@ if os.name == 'nt':
         # This blocks until the other side of the fifo is opened
         win32pipe.ConnectNamedPipe(pipe, None)
 
-        return pipe
+        return WindowsPipe(pipe)
 
 ##########################
 # END WINDOWS FIFO PATCH #
@@ -133,10 +133,7 @@ if os.name == 'nt':
 
 class Formatter:
     def __init__(self, out):
-        if os.name == 'nt':
-            self.out = WindowsPipe(out)
-        else:
-            self.out = out
+         self.out = out
 
     def fileno(self):
         return self.out.fileno()

--- a/serial-pcap
+++ b/serial-pcap
@@ -38,9 +38,125 @@ import binascii
 import datetime
 import argparse
 
+ ############################
+ # START WINDOWS FIFO PATCH #
+ ############################
+
+if os.name == 'nt':
+    import win32file
+    import win32pipe
+
+    ######
+    # Windows Patch Class Definitions
+    ######
+
+    class Poller:
+        """Basic select.poll() implementation for Windows.
+        
+        Credit: https://gist.github.com/gustaebel/b58e887ba93a4d0eba102dae871e11af
+        """
+
+        def __init__(self):
+            self.r = []
+            self.w = []
+            self.e = []
+
+        def register(self, sock, eventmask=None):
+            if eventmask is None:
+                eventmask = select.POLLIN | select.POLLOUT | select.POLLPRI
+
+            if eventmask & select.POLLIN or eventmask & select.POLLERR:
+                self.r.append(sock)
+            if eventmask & select.POLLOUT:
+                self.w.append(sock)
+            if eventmask & select.POLLPRI:
+                self.e.append(sock)
+
+        def unregister(self, sock):
+            for l in (self.r, self.w, self.e):
+                try:
+                    l.remove(sock)
+                except IndexError:
+                    pass
+
+        def _poll(self, timeout):
+            if timeout is None:
+                r, w, e = select.select(self.r, self.w, self.e)
+            else:
+                r, w, e = select.select(self.r, self.w, self.e, int(timeout / 1000))
+
+            sockets = set(r) | set(w) | set(e)
+            for sock in sockets:
+                event = 0
+                if sock in r:
+                    event |= select.POLLIN
+                if sock in w:
+                    event |= select.POLLOUT
+                if sock in e:
+                    event |= select.POLLPRI
+                yield sock, event
+
+        def poll(self, timeout=None):
+            return list(self._poll(timeout))
+
+    class WindowsPipe:
+        def __init__(self, pipe):
+            self.pipe = pipe
+        
+        def fileno(self):
+            return self.pipe.__int__()
+
+        def write(self, data):
+            win32file.WriteFile(self.pipe, data)
+        
+        def flush(self):
+            win32file.FlushFileBuffers(self.pipe)
+
+        def close(self):
+            win32file.CloseHandle(self.pipe)
+
+    class WindowsSerial(serial.Serial):
+        def fileno(self):
+            return self.in_waiting
+
+    ######
+    # Windows Patch Function Definitions
+    ######
+
+    def win32_poll_install():
+        """Credit: https://gist.github.com/gustaebel/b58e887ba93a4d0eba102dae871e11af
+        """
+        select.poll = Poller
+        select.POLLIN = 1
+        select.POLLOUT = 2
+        select.POLLPRI = 4
+        select.POLLERR = 8
+
+    def open_fifo_windows(options, name):
+        pipe = win32pipe.CreateNamedPipe(
+            fr'\\.\pipe\{name}',
+            win32pipe.PIPE_ACCESS_OUTBOUND,
+            win32pipe.PIPE_TYPE_BYTE | win32pipe.PIPE_WAIT,
+            1, 65536, 65536, 0, None
+        )
+
+        if not options.quiet:
+            print("Waiting for fifo to be openend...")
+        # This blocks until the other side of the fifo is opened
+        win32pipe.ConnectNamedPipe(pipe, None)
+
+        return pipe
+
+##########################
+# END WINDOWS FIFO PATCH #
+##########################
+
 class Formatter:
     def __init__(self, out):
-        self.out = out
+        if os.name == 'nt':
+            self.out = WindowsPipe(out)
+        else:
+            self.out = out
 
     def fileno(self):
         return self.out.fileno()
@@ -82,7 +198,7 @@ class HumanFormatter(Formatter):
         self.out.write("\n")
         self.out.flush()
 
-def open_fifo(options, name):
+def open_fifo_linux(options, name):
     try:
         os.mkfifo(name);
     except FileExistsError:
@@ -97,7 +213,14 @@ def open_fifo(options, name):
 
 def setup_output(options):
     if options.fifo:
+        if os.name == "nt":
+            open_fifo = open_fifo_windows
+            win32_poll_install()
+        else:
+            open_fifo = open_fifo_linux
+        
         return PcapFormatter(open_fifo(options, options.fifo))
+    
     elif options.write_file:
         return PcapFormatter(open(options.write_file, 'wb'))
     else:
@@ -136,8 +259,11 @@ def do_sniff_once(options):
     # This might block until the other side of the fifo is opened
     out = setup_output(options)
     out.write_header()
-
-    ser = serial.Serial(options.port, options.baudrate)
+    
+    if os.name == 'nt':
+        ser = WindowsSerial(options.port, options.baudrate)
+    else:
+        ser = serial.Serial(options.port, options.baudrate)
     print("Opened {} at {}".format(options.port, options.baudrate))
 
     if options.send_init_delay:

--- a/serial-pcap
+++ b/serial-pcap
@@ -33,7 +33,7 @@ import time
 import errno
 import serial
 import struct
-import select
+import selectors
 import binascii
 import datetime
 import argparse
@@ -43,68 +43,22 @@ import argparse
  ############################
 
 if os.name == 'nt':
+    from pywintypes import HANDLEType
     import win32file
     import win32pipe
+    import win32security
+    import ntsecuritycon
 
     ######
     # Windows Patch Class Definitions
     ######
 
-    class Poller:
-        """Basic select.poll() implementation for Windows.
-        
-        Credit: https://gist.github.com/gustaebel/b58e887ba93a4d0eba102dae871e11af
-        """
-
-        def __init__(self):
-            self.r = []
-            self.w = []
-            self.e = []
-
-        def register(self, sock, eventmask=None):
-            if eventmask is None:
-                eventmask = select.POLLIN | select.POLLOUT | select.POLLPRI
-
-            if eventmask & select.POLLIN or eventmask & select.POLLERR:
-                self.r.append(sock)
-            if eventmask & select.POLLOUT:
-                self.w.append(sock)
-            if eventmask & select.POLLPRI:
-                self.e.append(sock)
-
-        def unregister(self, sock):
-            for l in (self.r, self.w, self.e):
-                try:
-                    l.remove(sock)
-                except IndexError:
-                    pass
-
-        def _poll(self, timeout):
-            if timeout is None:
-                r, w, e = select.select(self.r, self.w, self.e)
-            else:
-                r, w, e = select.select(self.r, self.w, self.e, int(timeout / 1000))
-
-            sockets = set(r) | set(w) | set(e)
-            for sock in sockets:
-                event = 0
-                if sock in r:
-                    event |= select.POLLIN
-                if sock in w:
-                    event |= select.POLLOUT
-                if sock in e:
-                    event |= select.POLLPRI
-                yield sock, event
-
-        def poll(self, timeout=None):
-            return list(self._poll(timeout))
-
     class WindowsPipe:
         def __init__(self, pipe):
-            self.pipe = pipe
+            self.pipe:HANDLEType = pipe
         
         def fileno(self):
-            return self.pipe.__int__()
+            return self.pipe
 
         def write(self, data):
             win32file.WriteFile(self.pipe, data)
@@ -114,30 +68,46 @@ if os.name == 'nt':
 
         def close(self):
             win32file.CloseHandle(self.pipe)
-
+    
     class WindowsSerial(serial.Serial):
         def fileno(self):
-            return self.in_waiting
+            return int(self.name[3:])
+    
+    class WindowsSelector(selectors.SelectSelector):
+        def _select(self, r, w, _, timeout = None):
+            retr = []
+            retw = []
+            
+            for rfd in r:
+                rfo:WindowsSerial = self.get_key(rfd).fileobj
+                if rfo.in_waiting == 0:
+                    retr.append(rfd)
+            
+            for wfd in w:
+                wfo:PcapFormatter = self.get_key(wfd).fileobj
+                pipe = wfo.out.pipe
+                _, available_bytes, _ = win32pipe.PeekNamedPipe(pipe, 0)
+                
+                if available_bytes != 0:
+                    retw.append(wfd)
+            
+            return retr, retw, []
+                
 
     ######
     # Windows Patch Function Definitions
     ######
 
-    def win32_poll_install():
-        """Credit: https://gist.github.com/gustaebel/b58e887ba93a4d0eba102dae871e11af
-        """
-        select.poll = Poller
-        select.POLLIN = 1
-        select.POLLOUT = 2
-        select.POLLPRI = 4
-        select.POLLERR = 8
-
     def open_fifo_windows(options, name):
         pipe = win32pipe.CreateNamedPipe(
             fr'\\.\pipe\{name}',
-            win32pipe.PIPE_ACCESS_OUTBOUND,
+            win32pipe.PIPE_ACCESS_DUPLEX,
             win32pipe.PIPE_TYPE_BYTE | win32pipe.PIPE_WAIT,
-            1, 65536, 65536, 0, None
+            1, 
+            65536, 
+            65536, 
+            0,
+            None
         )
 
         if not options.quiet:
@@ -215,7 +185,6 @@ def setup_output(options):
     if options.fifo:
         if os.name == "nt":
             open_fifo = open_fifo_windows
-            win32_poll_install()
         else:
             open_fifo = open_fifo_linux
         
@@ -264,6 +233,7 @@ def do_sniff_once(options):
         ser = WindowsSerial(options.port, options.baudrate)
     else:
         ser = serial.Serial(options.port, options.baudrate)
+        
     print("Opened {} at {}".format(options.port, options.baudrate))
 
     if options.send_init_delay:
@@ -289,16 +259,20 @@ def do_sniff_once(options):
         print("Waiting for packets...")
 
     count = 0
-    poll = select.poll()
+    if os.name == 'nt':
+        poll = WindowsSelector()
+    else:
+        poll = selectors.DefaultSelector()
+        
     # Wait to read data from serial, or until the fifo is closed
-    poll.register(ser, select.POLLIN)
-    poll.register(out, select.POLLERR)
+    poll.register(ser, selectors.EVENT_READ)
+    poll.register(out, selectors.EVENT_WRITE)
 
     while True:
         # Wait for something to do
-        events = poll.poll()
+        events = poll.select()
 
-        fds = [fd for (fd, evt) in events]
+        fds = [fd.fileobj.fileno() for (fd,evt) in events]
         if out.fileno() in fds:
             # Error on output, e.g. fifo closed on the other end
             break


### PR DESCRIPTION
I attempted to write this patch with as little change to your written code as possible. 

Implemented a simple wrapper for the pipe and serial objects as well as implementing a windows-based, non-file, select.select() method. 

Usage on windows will look like:
```
python serial-pcap --fifo mypipename COM#
```

This differs from the linux fifio because you are not declaring a "file" in a directory. You're just declaring a name. This is due to how Named Pipes work and how they have to be in the Named Pipe directory. 

This will produce a pipe in the named pipe directory, `\\.\pipe\` that can be used in the Windows version of pipe just like the Linux fifo. So, you would put into the "pipe" section `\\.\pipe\mypipename`. 

The ability to use `select()` with a fifo on windows comes from the fact that the I have switched to a `selectors`-based I/O Multiplexor instead of the previously used `select`-based.

I've done some quick tests to make sure that this works on both linux and windows, and it seems too still function as it did previously. 
